### PR TITLE
adding ability to set trailing comma, useful when you copy generated entry to the json

### DIFF
--- a/src/lib/generateTranslationString.ts
+++ b/src/lib/generateTranslationString.ts
@@ -30,7 +30,7 @@ export async function generateTranslationString() {
   // Generate a json key/value pair
   const value = `"${key}": "${selectedText}"`;
   // Copy the translation json to the clipboard
-  copypaste.copy(value + ",");
+  copypaste.copy(value);
 
   if (settings.get('replaceOnTranslate')) {
     // Replace the selection text with the translated key

--- a/src/lib/generateTranslationString.ts
+++ b/src/lib/generateTranslationString.ts
@@ -24,12 +24,13 @@ export async function generateTranslationString() {
   const key = getTranslationKeyFromString(
     input,
     settings.get('caseMode'),
-    settings.get('autocapitalize')
+    settings.get('autocapitalize'),
+    settings.get('addTrailingComma'),
   );
   // Generate a json key/value pair
   const value = `"${key}": "${selectedText}"`;
   // Copy the translation json to the clipboard
-  copypaste.copy(value);
+  copypaste.copy(value + ",");
 
   if (settings.get('replaceOnTranslate')) {
     // Replace the selection text with the translated key
@@ -47,8 +48,12 @@ export async function generateTranslationString() {
 export function getTranslationKeyFromString(
   input: string,
   caseMode: string = 'snake',
-  autocapitalize: boolean = true
+  autocapitalize: boolean = true,
+  addTrailingComma: boolean = true,
 ) {
+  if (addTrailingComma){
+    input = input + ",";
+  }
   if (caseMode === 'camel') {
     return camelize(input);
   } else if (caseMode === 'snake') {


### PR DESCRIPTION
maybe you'll want to add separator option instead of `true/false` for comma
I didn't test this properly - I edited actual extension on my local, but here you have another version
btw this is great extension, saves a lot of time  :+1: 